### PR TITLE
fix: handle null password in AuthService

### DIFF
--- a/src/main/java/service/AuthService.java
+++ b/src/main/java/service/AuthService.java
@@ -1,12 +1,16 @@
 package service;
+
+import java.util.Objects;
+
 import model.User;
 import repo.InMemoryUserRepository;
 
 public class AuthService {
     private final InMemoryUserRepository users = InMemoryUserRepository.getInstance();
-    public User login(String username, String password){
+
+    public User login(String username, String password) {
         var u = users.findByUsername(username);
-        if (u != null && u.getPassword().equals(password)) return u;
+        if (u != null && Objects.equals(u.getPassword(), password)) return u;
         return null;
     }
 }


### PR DESCRIPTION
## Summary
- prevent null pointer in login by comparing passwords using `Objects.equals`

## Testing
- `mvn -q test` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68acb3feefd0832c95c0997b33d665e2